### PR TITLE
Refactor CORS header configuration in mapproxy.yaml

### DIFF
--- a/mapproxy.yaml
+++ b/mapproxy.yaml
@@ -9,24 +9,14 @@
 # - Runout Area from NVE (file cached)
 
 
-# Define a YAML anchor for the CORS header
-cors_headers: &cors_headers
-  headers:
-    Access-Control-Allow-Origin: $CORS_ALLOWED_ORIGINS
-
-
 services:
   demo:
-    <<: *cors_headers
   wmts:
-    <<: *cors_headers
   wms:
     srs: ["EPSG:3857"]
     image_formats: ["image/png", "image/jpeg"]
     on_source_errors: notify
-    <<: *cors_headers
   tms:
-    <<: *cors_headers
 
 
 layers:
@@ -113,3 +103,6 @@ globals:
       port: $MAPPROXY_REDIS_PORT
       username: $MAPPROXY_REDIS_USERNAME
       password: $MAPPROXY_REDIS_PASSWORD
+  http:
+    headers:
+      access_control_allow_origin: $CORS_ALLOWED_ORIGINS


### PR DESCRIPTION
Removed YAML anchor for CORS headers and added CORS header configuration under the HTTP section.